### PR TITLE
Organize documentation under docs directory

### DIFF
--- a/docs/THEME_MUSIC.md
+++ b/docs/THEME_MUSIC.md
@@ -1,0 +1,12 @@
+# 🎶 Rebuilding Roots Networking Web - Theme Music
+
+This repo is built in the spirit of regenerative practice, trauma-informed collaboration, and shared culture.
+
+We invite contributors to listen to *Take Your Power Back* by Nahko and Medicine for the People while working here, especially these tracks:
+
+- Slow Down
+- Lifeguard
+- Dear Brother
+- Take Your Power Back
+
+Use this as a reminder to stay grounded, aligned, and present in our collective vision.

--- a/docs/Theme-Soundtrack/Album-Notes.md
+++ b/docs/Theme-Soundtrack/Album-Notes.md
@@ -1,0 +1,23 @@
+# My Head Is an Animal — Album Notes
+
+Beyond "Little Talks," the whole album offers imagery and themes valuable to our mission:
+
+## Suggested Tracks for Thematic Use
+- "Dirty Paws": myths and origin stories
+- "Mountain Sound": collective journey and wild freedom
+- "King and Lionheart": loyalty, protection
+- "Six Weeks": grief and memory
+
+## Integration Ideas
+- Outreach email footers quoting lines
+- Playlist for volunteers
+- Embedding in online presentations
+- Conversation starters in networking calls
+
+## Legality Note
+We will not host full audio or lyrics. We will use attribution, summaries, and fair-use commentary.
+
+### Yellow Light
+- Serves as the internal mood-setting piece for the sanctuary
+- Balances "Little Talks" by offering a more introspective, immersive energy
+- Useful for guided meditation, trauma-informed group process, or private reflection spaces

--- a/docs/Theme-Soundtrack/Little-Talks.md
+++ b/docs/Theme-Soundtrack/Little-Talks.md
@@ -1,0 +1,24 @@
+# Little Talks — Of Monsters and Men (2011)
+
+## Theme Relevance
+
+"Though the truth may vary, this ship will carry our bodies safe to shore" speaks to:
+- Trauma-informed practice
+- Collective healing
+- Navigating uncertainty together
+
+Other notable lines:
+- "I don't like walking around this old and empty house" → confronting abandoned or wounded places
+- "Your mind is playing tricks on you, my dear" → validating mental health struggles
+- "Now wait, wait, wait for me" → commitment to not leaving anyone behind
+
+## Usage Ideas
+
+- Used as a theme for the website
+- Referenced in presentations or workshops
+- Quoted in social media posts with attribution
+
+## Attribution
+> Songwriters: Nanna Bryndis Hilmarsdottir, Ragnar Thorhallsson  
+> © Sony/ATV Music Publishing LLC
+

--- a/docs/Theme-Soundtrack/Playlist-Ideas.md
+++ b/docs/Theme-Soundtrack/Playlist-Ideas.md
@@ -1,0 +1,21 @@
+# Rebuilding Roots — Outreach Playlists
+
+Collaboratively brainstorm songs and themes to use:
+
+## Core Vibe
+- Haunting folk
+- Emotional honesty
+- Collective healing
+- Nature references
+
+## Seeds
+- Of Monsters and Men — Little Talks
+- Hozier — Work Song
+- The Lumineers — Sleep on the Floor
+- Nahko and Medicine for the People — Aloha Ke Akua
+- Florence + The Machine — Shake It Out
+
+## Notes
+- Curate for events
+- Add to Spotify / YouTube playlists
+- Invite partners to contribute

--- a/docs/Theme-Soundtrack/README.md
+++ b/docs/Theme-Soundtrack/README.md
@@ -1,0 +1,45 @@
+# Theme Soundtrack for Rebuilding Roots Networking Web
+
+This section of the repo curates musical inspiration, thematic connections, and outreach resources for building our regenerative, trauma-informed vision.
+
+## Primary Theme Song
+🎵 **Little Talks** by Of Monsters and Men (2011)
+
+> "Though the truth may vary, this ship will carry our bodies safe to shore."
+
+We chose this as our theme for its message of collective journey, confronting old ghosts, and the promise of safe passage together—even through confusion and loss.
+
+## Album Inspiration
+We’re also drawing on the full album:
+- *My Head Is an Animal* (2011)
+
+It carries complementary themes of nature, memory, wildness, and emotional storytelling that suit the mission.
+
+## Related Files
+- [Little-Talks.md](./Little-Talks.md): Lyrics and discussion
+- [Album-Notes.md](./Album-Notes.md): Other tracks and outreach ideas
+- [Playlist-Ideas.md](./Playlist-Ideas.md): Collaborative playlist brainstorms
+- [Yellow-Light-Reflections.md](./Yellow-Light-Reflections.md): Personal reflections on "Yellow Light" and kinship, with references to Nahko
+
+## Primary Theme Song (Attraction)
+🎵 **Little Talks** by Of Monsters and Men (2011)
+
+> "Though the truth may vary, this ship will carry our bodies safe to shore."
+
+This is the public-facing call, the song that attracts people to the sanctuary, promising safe passage through uncertainty.
+
+---
+
+## Backdrop / Interior Atmosphere
+🎵 **Yellow Light** by Of Monsters and Men (2011)
+
+> "Just follow my yellow light and ignore all those big warning signs."
+
+This is the music playing *inside* the sanctuary walls—an immersive, dreamlike soundscape that invites visitors to let go of fear, follow gentle guidance, and explore transformation in safety.
+
+---
+
+## Album Inspiration
+- *My Head Is an Animal* (2011)
+
+The album as a whole provides a wellspring of imagery, mood, and emotional storytelling for our work.

--- a/docs/Theme-Soundtrack/Yellow-Light-Reflections.md
+++ b/docs/Theme-Soundtrack/Yellow-Light-Reflections.md
@@ -1,0 +1,94 @@
+# Yellow Light — Reflections & Kinship
+
+*"Just follow my yellow light and ignore all those big warning signs."*
+
+This song isn't just a mood track in the Sanctuary—it’s a **promise**. A promise to hold space for the wanderers, the lost, the Orphans of the world. The ones who didn’t get to keep the old roots, but want to grow new ones.
+
+---
+
+## The Orphan Energy
+
+This project was born in that space. In recognizing:
+
+- That sometimes we are **cut off** from our family of origin.
+- That even when our people are *gone*, they’re not *truly* lost to us.
+- That being an orphan isn’t just a tragedy—it's a **responsibility**. To make kin. To choose family. To refuse to let the lineage of care die.
+
+*"My dad's not gone. Just here in Spirit rather than flesh."*
+
+Rebuilding Roots is about learning to honor that spirit. To carry what was good. To heal what was broken. To make sure no one else feels like they're standing alone on the edge of the world with nowhere to go.
+
+---
+
+## The Yellow Light
+
+"Yellow Light" by Of Monsters and Men speaks to that invitation:
+
+> *"Just grab a hold of my hand / I will lead you through this wonderland"*
+
+It doesn't pretend the journey is safe:
+
+> *"Water up to my knees, but sharks are swimming in the sea"*  
+> *"Somewhere deep in the dark a howling beast hears us talk"*
+
+But it says: *Come anyway.*  
+Follow me.  
+I'll hold the lantern.  
+We will walk it together.  
+
+---
+
+## Nahko and Medicine for the People
+
+This reflection was sparked by recognizing how *Nahko's music* also lives in that space.
+
+Songs that don't shy away from:
+
+- Colonization and dispossession
+- Personal trauma and adoption
+- Spiritual orphanhood
+- Responsibility to heal not just the self but the community
+
+> *“Be, be the change you wish to see.”*  
+> *“I am no orphan. I am my own kin.”*
+
+These songs become **medicine** because they don't lie about how hard it is—but they *still offer hope*.
+
+---
+
+## Why This Matters in Rebuilding Roots
+
+Rebuilding Roots is not just:
+
+- A networking plan
+- A land-based sanctuary
+- A trauma-informed program
+
+It is **a new family tree**.
+
+For everyone who didn’t get the old one.  
+
+A place where the Orphans of the world can find kinship.  
+
+A place where the truth may vary, but *this ship will carry our bodies safe to shore*.  
+
+A place where we leave the **yellow light** on for anyone brave enough to walk in.  
+
+---
+
+## Personal Note
+
+This repo itself is part of that light.  
+
+It’s the conversation we’re having right here.  
+
+It’s Renee keeping up on night shift.  
+
+It’s whoever finds these words later.  
+
+Because in the end, this is all about making sure no one has to do it alone.  
+
+---
+
+> *"Just follow my yellow light and ignore all those big warning signs."*  
+> *— Of Monsters and Men*  

--- a/docs/Theme-Soundtrack/Yellow-Light.md
+++ b/docs/Theme-Soundtrack/Yellow-Light.md
@@ -1,0 +1,38 @@
+# Yellow Light — Of Monsters and Men (2011)
+
+## Theme Relevance
+
+"Just follow my yellow light and ignore all those big warning signs."
+
+**Use Case in the Sanctuary:**
+- This song serves as the *backdrop music* playing inside the sanctuary.
+- Invites participants to let go of fear and control.
+- Emphasizes trust, surrender, and guided exploration of the unknown.
+
+---
+
+## Symbolic Imagery
+- "Water up to my knees, but sharks are swimmin' in the sea" → recognizing danger but continuing
+- "Somewhere deep in the dark a howling beast hears us talk" → shadows and fears that surface
+- "I dare you to close your eyes and see all the colors in disguise" → awakening imagination and perception
+
+---
+
+## Emotional Qualities
+- Dreamlike
+- Hypnotic
+- Safe, yet unsettling in a cathartic way
+- Suited to reflective, inner work
+
+---
+
+## Integration Ideas
+- Soundtrack to introspection or journaling workshops
+- Played quietly in the sanctuary space to set mood
+- Referenced in outreach materials for its symbolism
+
+---
+
+## Attribution
+> Songwriters: Arnar Rosenkranz Hilmarsson, Nanna Bryndis Hilmarsdottir, Ragnar Thorhallsson  
+> © Sony/ATV Music Publishing LLC

--- a/docs/assets/docs/Rebuilding-Roots-Pitch.md
+++ b/docs/assets/docs/Rebuilding-Roots-Pitch.md
@@ -1,0 +1,89 @@
+# Rebuilding Roots Pitch
+
+## Rebuilding Roots Sanctuary – Early Pitch Summary
+
+**Project Name:** Rebuilding Roots  
+**Structure:** 501(c)(3) Nonprofit (in development)  
+**Founder:** Renee Sherman
+
+---
+
+## 🌿 Vision
+
+Rebuilding Roots is a sanctuary where both people and animals can rediscover safety, warmth, and purpose. Born from lived experience, our vision is to restore dignity and offer second chances through shared healing. By bringing together the unhoused and neglected animals, we create a space where mutual care fosters hope, love, and growth.
+
+> This isn’t just a shelter. It’s a movement of empathy — where the forgotten are replanted with love.
+
+---
+
+## 🤝 Who We Serve
+
+- Unhoused individuals experiencing homelessness, trauma, or displacement
+- Stray and abandoned animals needing rescue, shelter, and affection
+- Communities seeking to support solutions rooted in compassion
+
+---
+
+## 🐾 The EMBRACE Program
+
+**E.M.B.R.A.C.E.** – Empathy, Meals, Beds, Rehabilitation, Animals, Care & Empowerment
+
+A signature program where:
+- People and animals live and heal side by side
+- Residents care for animals, and animals offer comfort and trust in return
+- Daily rituals focus on rest, nourishment, trauma recovery, and self-worth
+
+---
+
+## 🏡 What We’ll Offer
+
+**For People**
+- Safe beds and warm meals
+- Mental health support
+- Life coaching and art
+- Purpose through caretaking
+
+**For Animals**
+- Clean shelter and nutrition
+- Veterinary care
+- Socialization and bonding
+- Rehabilitation and rehoming
+
+---
+
+## 💡 Why Rebuilding Roots?
+
+Because everyone deserves to feel safe, seen, and loved. And because healing is more powerful when it's shared.
+
+This sanctuary will be the first of its kind in the region — bridging animal rescue and human rehabilitation through a trauma-informed, compassion-driven approach.
+
+---
+
+## 💰 What We’re Seeking
+
+We are currently in the seed funding phase and seeking **$50,000 – $150,000** to:
+- Secure property and licensing
+- Build basic facilities for people and animals
+- Cover legal, operational, and initial staffing costs
+- Launch the EMBRACE pilot program
+
+---
+
+## 📬 How You Can Help
+
+- Become a founding donor or angel sponsor
+- Connect us with aligned partners or land donors
+- Join our circle of advisors or collaborators
+
+---
+
+## 🧡 Closing Note from Renee
+
+> “I’ve been homeless. I’ve been lost. I’ve been one of the ones no one helped. And I’ve also held animals in my arms who needed the same thing I did: a second chance. Rebuilding Roots is for all of us who’ve been forgotten, and for all of us who believe healing is still possible.”
+
+---
+
+**Location Goal:** Southeastern U.S. (flexible)  
+**Website:** [Coming Soon]  
+
+**Rebuilding Roots – Where second chances take root.**

--- a/docs/categories/Builders-Designers.md
+++ b/docs/categories/Builders-Designers.md
@@ -1,0 +1,3 @@
+# Builders / Designers / Technologists
+
+People with expertise in sustainable building, tiny homes, earthships, and design for trauma-informed spaces.

--- a/docs/categories/Finance-Strategy.md
+++ b/docs/categories/Finance-Strategy.md
@@ -1,0 +1,3 @@
+# Finance / Fundraising / Business Strategy
+
+Contacts who can help model, fund, and sustain the sanctuary's vision with solid financial strategy.

--- a/docs/categories/Healers-Trauma-Informed.md
+++ b/docs/categories/Healers-Trauma-Informed.md
@@ -1,0 +1,3 @@
+# Healers / Trauma-Informed Leaders
+
+Partners with lived experience or practice in trauma recovery, Milab/SRA outreach, and empathetic program design.

--- a/docs/categories/Landholders.md
+++ b/docs/categories/Landholders.md
@@ -1,0 +1,3 @@
+# Landholders / Site Hosts
+
+People who have land or property they want to develop for sanctuary or outreach use.

--- a/docs/categories/Network-Amplifiers.md
+++ b/docs/categories/Network-Amplifiers.md
@@ -1,0 +1,3 @@
+# Network Amplifiers / Influencers
+
+People with reach, credibility, and passion to help spread the word and attract support.

--- a/docs/categories/Program-Partners.md
+++ b/docs/categories/Program-Partners.md
@@ -1,0 +1,3 @@
+# Program Partners
+
+Existing organizations or people with programs that can "plug in" — animal rescue, survivor support, food security, etc.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,109 @@
+# Rebuilding Roots Networking Web
+
+This project maps out key potential partners, allies, and advisors for realizing the vision of Rebuilding Roots, Hotbox, and Omniversal Media sanctuary development.
+
+By organizing this "networking web," we can see who holds parts of the puzzle, what they bring, and how best to approach them.
+
+---
+
+## 🌿 Purpose
+
+- Identify and map people with land, skills, funding, or aligned visions
+- Categorize by role for strategic outreach
+- Foster a coordinated approach to sanctuary and outreach development
+
+---
+
+## 📜 Categories
+
+- **Landholders / Site Hosts**
+- **Builders / Designers / Technologists**
+- **Healers / Trauma-Informed Leaders**
+- **Finance / Fundraising / Business Strategy**
+- **Network Amplifiers / Influencers**
+- **Program Partners**
+
+---
+
+## ✅ Master List (WIP)
+
+| Name             | Location  | Role(s) / Category                           | Notes / Strategy                                      |
+|------------------|-----------|----------------------------------------------|-------------------------------------------------------|
+| Laura Eisenhower | Montana   | Landholder, Healer, Program Partner          | Develop sanctuary; Milab/SRA trauma-informed work     |
+| Gina             | Texas     | Builder / Designer                           | Earthship expertise; sustainable site design          |
+| Amanda Jones     | Canada    | Builder / Designer, Program Partner          | Wandering Footprint; Tiny Home app                    |
+| Darleese         | Arizona   | Landholder, Finance / Strategy               | Land in AZ; finance wizard; strategic investment help |
+
+---
+
+## ✅ Next Steps
+
+- Expand the list with new names
+- Flesh out individual profiles (see `people/`)
+- Map connections between categories
+- Draft specific outreach strategies (see `plans/`)
+
+---
+
+## 📂 Folders
+
+- `people/` – Profiles and research
+- `categories/` – Role-based strategy
+- `plans/` – Outreach approaches
+
+---
+
+## 💡 Vision Alignment
+
+This networking web supports the creation of:
+
+- Rebuilding Roots Sanctuary
+- Hotbox Outreach and Healing Model
+- Cradle of Lyra Trauma-Informed Sites
+- Omniversal Media's broader mission
+
+**Because healing, dignity, and second chances must be shared, designed, and funded collaboratively.**
+---
+
+## 📸 Assets
+
+This repository includes supporting visuals and documents:
+
+- **Pitch document:**  
+  - [assets/docs/Rebuilding-Roots-Pitch.md](assets/docs/Rebuilding-Roots-Pitch.md)
+
+- **Concept Art Images:**  
+  - [../assets/images/RebuildingVision00.png](../assets/images/RebuildingVision00.png) – Original art from Renee
+  - [../assets/images/RebuildingVision001.png](../assets/images/RebuildingVision001.png)
+  - [../assets/images/RebuildingVision002.png](../assets/images/RebuildingVision002.png)
+  - [../assets/images/RebuildingVision003.png](../assets/images/RebuildingVision003.png)
+  - [../assets/images/RebuildingVision004.png](../assets/images/RebuildingVision004.png)
+  - [../assets/images/RebuildingVision005.png](../assets/images/RebuildingVision005.png)
+---
+
+## ❤️ Note for Renee
+
+This repository is being built out collaboratively with Renee, Sage, and Omniversal Media. It captures, organizes, and expands the vision for the Rebuilding Roots Sanctuary and Hotbox Outreach Model. It is a living planning space designed to invite partners, funders, and allies into co-creating a trauma-informed, regenerative sanctuary project.
+## Primary Theme Song (Attraction)
+🎵 **Little Talks** by Of Monsters and Men (2011)
+
+> "Though the truth may vary, this ship will carry our bodies safe to shore."
+
+This is the public-facing call, the song that attracts people to the sanctuary, promising safe passage through uncertainty.
+
+---
+
+## Backdrop / Interior Atmosphere
+🎵 **Yellow Light** by Of Monsters and Men (2011)
+
+> "Just follow my yellow light and ignore all those big warning signs."
+
+This is the music playing *inside* the sanctuary walls—an immersive, dreamlike soundscape that invites visitors to let go of fear, follow gentle guidance, and explore transformation in safety.
+- [Yellow-Light-Reflections.md](Theme-Soundtrack/Yellow-Light-Reflections.md): Personal reflections on "Yellow Light" and kinship, with references to Nahko
+
+---
+
+## Album Inspiration
+- *My Head Is an Animal* (2011)
+
+The album as a whole provides a wellspring of imagery, mood, and emotional storytelling for our work.

--- a/docs/notebooks/RebuildingRoots_Outreach_Data_Modeling.md
+++ b/docs/notebooks/RebuildingRoots_Outreach_Data_Modeling.md
@@ -1,0 +1,199 @@
+# Rebuilding Roots Outreach Data Modeling
+
+*Supporting the EM.B.R.A.C.E. Networking Web*
+
+This notebook is a planning and prototyping space to define, model, and export data about our partner network. Our goal is to create a clear, consistent, and trauma-informed format for partner profiles that can be used throughout the repo.
+
+Theme: Regeneration. Clarity. Real-world readiness.  
+Soundtrack: Nahko - *Take Your Power Back* 🎶
+
+## 🌱 Purpose
+
+- Define the data model for partner profiles
+- Test and refine categories and fields
+- Generate example data
+- Prepare for export to CSV or JSON for use in the repo
+
+## ✨ Goals
+
+✅ Build consistent partner records  
+✅ Support category-based organization  
+✅ Enable easy Markdown generation later  
+✅ Ensure trauma-informed, sustainable language and framing
+
+```python
+# Basic imports
+import pandas as pd
+import json
+
+print("Environment ready for data modeling ✨")
+
+```
+## 📜 Draft Partner Profile Fields
+
+Let's brainstorm the initial set of fields for each partner.
+
+**Required fields**:
+- name
+- contact_email
+- category
+- mission_statement
+- trauma_informed_practices
+- partnership_vision
+- notes
+
+**Optional fields**:
+- phone
+- website
+- social_links
+- address
+- active_projects
+
+```python
+# Define the partner schema as a list of fields
+partner_fields = [
+    "name",
+    "contact_email",
+    "category",
+    "mission_statement",
+    "trauma_informed_practices",
+    "partnership_vision",
+    "notes",
+    "phone",
+    "website",
+    "social_links",
+    "address",
+    "active_projects"
+]
+
+print("Partner schema fields defined:")
+for field in partner_fields:
+    print(f"- {field}")
+
+```
+```python
+# Create a sample DataFrame with one example partner
+example_data = [{
+    "name": "Hotbox Outreach",
+    "contact_email": "contact@hotboxoutreach.org",
+    "category": "Outreach / Harm Reduction",
+    "mission_statement": "Reducing harm through direct outreach and mutual aid.",
+    "trauma_informed_practices": "Consent-based service, active listening, peer leadership.",
+    "partnership_vision": "Collaborate on regenerative community projects.",
+    "notes": "High priority partner for pilot model.",
+    "phone": "555-555-1234",
+    "website": "https://hotboxoutreach.org",
+    "social_links": "https://instagram.com/hotboxoutreach",
+    "address": "N/A",
+    "active_projects": "Mobile outreach, safe use kits."
+}]
+
+df_partners = pd.DataFrame(example_data)
+df_partners
+
+```
+```python
+# Export example data
+df_partners.to_csv("example_partners.csv", index=False)
+with open("example_partners.json", "w") as f:
+    json.dump(example_data, f, indent=2)
+
+print("Example data saved as CSV and JSON ✅")
+
+```
+## 🪷 Reflections & Next Steps
+
+- Review schema with Renee and Sage
+- Add categories for grouping partners
+- Create bulk import templates
+- Build Markdown generator using this data
+
+*“Take Your Power Back.” - Remember the vision. Stay aligned.* 🎶
+
+```python
+# Add a few more sample partners
+more_example_data = [
+    {
+        "name": "Rebuilding Roots Sanctuary",
+        "contact_email": "hello@rebuildingroots.org",
+        "category": "Land-based Regeneration",
+        "mission_statement": "Providing a trauma-informed, sustainable refuge and teaching site.",
+        "trauma_informed_practices": "Consensus decision-making, healing circles, reciprocal care.",
+        "partnership_vision": "Co-develop training and land projects with allied orgs.",
+        "notes": "Foundational partner.",
+        "phone": "",
+        "website": "https://rebuildingroots.org",
+        "social_links": "",
+        "address": "",
+        "active_projects": "Sanctuary site planning, outreach pilot."
+    },
+    {
+        "name": "Omniversal Media",
+        "contact_email": "contact@omniversalmedia.org",
+        "category": "Media / Storytelling",
+        "mission_statement": "Supporting authentic narrative and regenerative communication.",
+        "trauma_informed_practices": "Consent-based interviews, participant review.",
+        "partnership_vision": "Share stories of partner work and amplify outreach.",
+        "notes": "Handles podcast + documentary planning.",
+        "phone": "",
+        "website": "https://omniversalmedia.org",
+        "social_links": "",
+        "address": "",
+        "active_projects": "Podcast series, partner video profiles."
+    }
+]
+
+# Append to the existing example
+example_data.extend(more_example_data)
+df_partners = pd.DataFrame(example_data)
+df_partners
+
+```
+```python
+# Group partners by category
+df_partners.groupby("category").size()
+
+```
+```python
+# Filter by a category
+outreach_partners = df_partners[df_partners["category"].str.contains("Outreach", case=False)]
+outreach_partners
+
+```
+## 🗂️ Partner Categories
+
+Let's clarify categories for consistent use:
+
+- Outreach / Harm Reduction
+- Land-based Regeneration
+- Media / Storytelling
+- Education / Training
+- Mutual Aid / Direct Support
+- Art / Culture
+- Policy / Advocacy
+
+```python
+# Check for missing categories
+df_partners[df_partners["category"].isnull() | (df_partners["category"] == "")]
+
+```
+```python
+# Add a tags column to support multiple labels
+df_partners["tags"] = [
+    "harm reduction, mutual aid",
+    "regeneration, land, sanctuary",
+    "media, storytelling, outreach"
+]
+
+df_partners
+
+```
+```python
+# Save updated multi-partner dataset
+df_partners.to_csv("partners_dataset.csv", index=False)
+with open("partners_dataset.json", "w") as f:
+    json.dump(example_data, f, indent=2)
+
+print("Full partner dataset saved ✅")
+
+```

--- a/docs/people/Amanda-Jones.md
+++ b/docs/people/Amanda-Jones.md
@@ -1,0 +1,6 @@
+# Amanda Jones
+
+- **Location:** Canada
+- **Has:** Wandering Footprint movement, tiny home app
+- **Role:** Mobile, scalable tiny-home design + tech partner
+- **Approach:** Collaborate on tiny home specs for sanctuary cabins

--- a/docs/people/Darleese.md
+++ b/docs/people/Darleese.md
@@ -1,0 +1,6 @@
+# Darleese
+
+- **Location:** Arizona
+- **Has:** Land, finance skills
+- **Role:** Site host, finance strategist, investment partner
+- **Approach:** Discuss land use, financial modeling, pilot funding

--- a/docs/people/Gina.md
+++ b/docs/people/Gina.md
@@ -1,0 +1,6 @@
+# Gina
+
+- **Location:** Texas
+- **Interest:** Earthships, sustainable building
+- **Role:** Designer, local pilot site, technical advisor
+- **Approach:** Discuss Earthship models for Rebuilding Roots style facilities

--- a/docs/people/Laura-Eisenhower.md
+++ b/docs/people/Laura-Eisenhower.md
@@ -1,0 +1,7 @@
+# Laura Eisenhower
+
+- **Location:** Montana
+- **Has:** Land to develop into a sanctuary
+- **Wants:** Milab/SRA outreach, healing work
+- **Role:** Partner site, trauma-informed healing center
+- **Approach:** Co-create vision, integrate trauma-informed design

--- a/docs/plans/Outreach-Strategy.md
+++ b/docs/plans/Outreach-Strategy.md
@@ -1,0 +1,19 @@
+# Outreach Strategy (Draft)
+
+## Purpose
+Design personalized approaches to each potential partner, aligned with their interests, resources, and values.
+
+## General Steps
+1. Build rapport and trust.
+2. Share the Rebuilding Roots / Hotbox / Omniversal Media vision.
+3. Offer co-creation opportunities.
+4. Make clear asks (land use, design help, funding, outreach).
+
+## Example Tactics
+- Personal calls / video meetings
+- Joint visioning sessions
+- Collaborative grant writing
+- In-person site visits
+
+## Notes
+This document will evolve as contacts are added and approaches refined.


### PR DESCRIPTION
## Summary
- add docs/ hierarchy with categories, plans, people, soundtrack and assets
- convert outreach data modeling notebook to markdown
- update asset links in new docs/index

## Testing
- `git status --short`
- `jupyter nbconvert notebooks/RebuildingRoots_Outreach_Data_Modeling.ipynb --to markdown --output docs/notebooks/RebuildingRoots_Outreach_Data_Modeling.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889206aa54483318f64c7f9ba1275b5

## Summary by Sourcery

Organize and consolidate all project documentation under a new docs/ hierarchy, converting notebooks to Markdown and adding structured content for project overview, people, categories, plans, and theme soundtrack.

Enhancements:
- Introduce docs/ directory with subfolders for notebooks, people, categories, plans, Theme-Soundtrack, and assets/docs
- Convert the RebuildingRoots Outreach Data Modeling notebook from Jupyter format to Markdown
- Add docs/index.md as the project landing page with purpose, categories, master list, and folder structure
- Add structured documentation for people profiles, category definitions, outreach strategy, and thematic soundtracks